### PR TITLE
Changed events this plugin listens to, making it much faster, and by this, less laggy.

### DIFF
--- a/after/syntax/css.vim
+++ b/after/syntax/css.vim
@@ -388,8 +388,8 @@ if has("gui_running") || &t_Co==256
   endwhile
   unlet i
 
-  autocmd CursorHold * silent call s:PreviewCSSColorInLine('.')
-  autocmd CursorHoldI * silent call s:PreviewCSSColorInLine('.')
+  autocmd CursorMoved * silent call s:PreviewCSSColorInLine('.')
+  autocmd CursorMovedI * silent call s:PreviewCSSColorInLine('.')
   if !exists('g:cssColorVimDoNotMessMyUpdatetime')
     set ut=100
   endif


### PR DESCRIPTION
Instead of listening to CursorHold it now listens to CursorMoved -- ut variable is probably no longer needed.
